### PR TITLE
Include User-Agent header in manual /oauth2/applications/@me call

### DIFF
--- a/backend/utils/index.ts
+++ b/backend/utils/index.ts
@@ -22,7 +22,12 @@ export const fetchPrivilegedIntents = async (token: string) => {
 	try {
 		const response = await fetch(
 			'https://discord.com/api/v10/oauth2/applications/@me',
-			{ headers: { Authorization: `Bot ${token}` } }
+			{
+				headers: {
+					Authorization: `Bot ${token}`,
+					'User-Agent': 'DiscordBot'
+				}
+			}
 		)
 		const { flags } = await response.json()
 


### PR DESCRIPTION
Discord API calls must include `User-Agent` header with "DiscordBot" substring, or it will encounter Cloudflare error.