### PR TITLE
Remove discord-api-types from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 		"@darkguy10/discord-markdown": "^2.6.0",
 		"@skyra/discord-components-core": "^3.3.0",
 		"@skyra/discord-components-react": "^3.3.0",
-		"discord-api-types": "^0.37.43",
 		"discord.js": "^14.11.0",
 		"electron-is-dev": "^2.0.0",
 		"electron-log": "^4.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7638,7 +7638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"discord-api-types@npm:^0.37.41, discord-api-types@npm:^0.37.43":
+"discord-api-types@npm:^0.37.41":
   version: 0.37.43
   resolution: "discord-api-types@npm:0.37.43"
   checksum: 716bafb6b2881fd0bb36edae67ec04d08e393ff80b762c74376a40d99cf6dace71d9b13242cea95df1fb9db3aa64fd3e94719dc983420e3b3e139f0e77258489
@@ -13999,15 +13999,15 @@ __metadata:
   linkType: hard
 
 "sass@npm:^1.64.0":
-  version: 1.64.0
-  resolution: "sass@npm:1.64.0"
+  version: 1.64.1
+  resolution: "sass@npm:1.64.1"
   dependencies:
     chokidar: ">=3.0.0 <4.0.0"
     immutable: ^4.0.0
     source-map-js: ">=0.6.2 <2.0.0"
   bin:
     sass: sass.js
-  checksum: b4eb9b1bdeb1c00e76427d7fe3e5f80d831327178cdee657aa4e014edfc64ebbfe43177147403da1e04d76a24f4093f5a9b1c8d9d80c94579937d8adc5a6ef66
+  checksum: e908f96f3d5fa5869e2f2aec97548c93d6ef390680af89870fcae8bdbaee2392ac650fbeae8d2ef8e4c99cb9f81e6b3624e1cb659af6d6e746332a22233b5ad8
   languageName: node
   linkType: hard
 
@@ -15968,7 +15968,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.59.9
     "@typescript-eslint/parser": ^5.59.9
     concurrently: ^8.1.0
-    discord-api-types: ^0.37.43
     discord.js: ^14.11.0
     electron: ^25.0.1
     electron-builder: ^23.6.0


### PR DESCRIPTION
`discord-api-types` is already required by `discord.js`, therefore it is unnecessary to add it explicitly to `package.json`.